### PR TITLE
refactor: AuditingFields class를 추상 class로 변경

### DIFF
--- a/src/main/java/com/hou27/basicboard/domain/base/AuditingFields.java
+++ b/src/main/java/com/hou27/basicboard/domain/base/AuditingFields.java
@@ -21,7 +21,7 @@ import org.springframework.format.annotation.DateTimeFormat;
  */
 @MappedSuperclass
 @EntityListeners({AuditingEntityListener.class})
-public class AuditingFields {
+public abstract class AuditingFields {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;


### PR DESCRIPTION
항상 상속받아 사용하고, 그 자체로 entity는 아니기 때문에
의미를 더욱 잘 나타내기 위해 추상 키워드를 추가